### PR TITLE
Adding PC members

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,5 @@ info@mlhpcs.org
 * Sunna Torge (ZIH, Dresden)
 
 ## Program Committee
--TBA- 
+* Dr. Jamal Toutouh. MIT Computer Science & Artificial Intelligence Lab (CSAIL)
+* Sebastien Varrette, PhD. University of Luxembourg &  UL High Performance Computing


### PR DESCRIPTION
I added the following two PC members
Dr. Toutouh works at MIT on distributed GANs for HPC
Sebastien Varrette, is the deputy head of Big Data and AI core and HPC at UNI Luxembourg supercomputer